### PR TITLE
🐞 fix maxZoomScale calculation error

### DIFF
--- a/VIPhotoView/VIPhotoView.m
+++ b/VIPhotoView/VIPhotoView.m
@@ -128,8 +128,8 @@
         self.needLayout = NO;
         
         // update container size
-        [self setMaxMinZoomScale];
         [self updateDisplayMode];
+        [self setMaxMinZoomScale];
         
         if (self.minSize.width == 0) {
             return;
@@ -344,7 +344,7 @@
 - (void)setMaxMinZoomScale
 {
     CGSize imageSize = self.imageView.image.size;
-    CGSize imagePresentationSize = [self.imageView.image sizeThatFits:self.bounds.size];
+    CGSize imagePresentationSize = self.contentSize;
     CGFloat maxScale = MAX(imageSize.height / imagePresentationSize.height, imageSize.width / imagePresentationSize.width);
     self.maximumZoomScale = MAX(1, maxScale); // Should not less than 1
     self.minimumZoomScale = 1.0;

--- a/VIPhotoViewDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/VIPhotoViewDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
当 ContentMode 为 VIPhotoViewContentModeScaleAspectFillToTop 时，imagePresentationSize 不能用 [self.imageView.image sizeThatFits:self.bounds.size] 来计算 